### PR TITLE
apply data extra when only data is present in response

### DIFF
--- a/src/Response/Handler/ResponseHandler.php
+++ b/src/Response/Handler/ResponseHandler.php
@@ -39,7 +39,7 @@ class ResponseHandler implements ResponseHandlerInterface
 
             $payload = Json::decode($body->__toString(), true, 512, self::JSON_OPTIONS);
 
-            if (isset($payload['data'])) {
+            if (isset($payload['data']) && count(array_keys($payload)) === 1) {
                 $payload = $payload['data'];
             }
 

--- a/test/suite/unit/Response/Handler/ResponseHandlerTest.php
+++ b/test/suite/unit/Response/Handler/ResponseHandlerTest.php
@@ -60,6 +60,45 @@ class ResponseHandlerTest extends TestCase
     /**
      * @covers ::handle
      */
+    public function testResponseWithDataAndExtraFields()
+    {
+        $handler = new ResponseHandler();
+
+        $testStatusCode  = 200;
+        $testRawBody     = '{"data":{"test-key":"test-value"},"total":1}';
+        $testHeaders     = ['X-Foo' => 'bar'];
+        $testBodySize    = 10;
+        $expectedBody    = ['data' => ['test-key' => 'test-value'], 'total' => 1];
+        $expectedHeaders = $testHeaders;
+
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->expects(self::once())
+            ->method('getSize')
+            ->willReturn($testBodySize);
+        $stream->expects(self::once())
+            ->method('__tostring')
+            ->willReturn($testRawBody);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects(self::once())
+            ->method('getBody')
+            ->willReturn($stream);
+        $response->expects(self::once())
+            ->method('getStatusCode')
+            ->willReturn($testStatusCode);
+        $response->expects(self::once())
+            ->method('getHeaders')
+            ->willReturn($testHeaders);
+
+        $result = $handler->handle($response);
+
+        self::assertEquals($expectedBody, $result->getPayload());
+        self::assertEquals($expectedHeaders, $result->getHeaders());
+    }
+
+    /**
+     * @covers ::handle
+     */
     public function testResponseWithData()
     {
         $handler = new ResponseHandler();


### PR DESCRIPTION
Right now we have this situation where API responds something like
```
{
    "data": ...,
    "total": ...
}
```
or any other field along "data" as a matter of fact. `ResponseHandler` greedily consumes any "data" and response schema doesn't match anymore. So this extra condition will validate if we have "data" and "data" alone in the response before consuming it.