### PR TITLE
Removed data key handling from ResponseHandler when handling payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2020-08-31
+### Changed
+- The response handling in `ResponseHandler`: Removed "data" key handling when handling payload.
+
 ## [2.0.1] - 2020-08-24
 ### Fixed
 - The superkey "data" handling in ResponseHandler.

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -8,16 +8,16 @@ class Response
     private $statusCode;
 
     /** @var array */
-    private $payload;
-
-    /** @var array */
     private $headers;
 
-    public function __construct(int $statusCode, array $payload = [], array $headers = [])
+    /** @var array */
+    private $payload;
+
+    public function __construct(int $statusCode, array $headers = [], $payload = null)
     {
         $this->statusCode = $statusCode;
-        $this->payload    = $payload;
         $this->headers    = $headers;
+        $this->payload    = $payload;
     }
 
     public function getStatusCode(): int
@@ -25,13 +25,13 @@ class Response
         return $this->statusCode;
     }
 
-    public function getPayload(): array
-    {
-        return $this->payload;
-    }
-
     public function getHeaders(): array
     {
         return $this->headers;
+    }
+
+    public function getPayload()
+    {
+        return $this->payload;
     }
 }

--- a/test/suite/unit/Response/Handler/ResponseHandlerTest.php
+++ b/test/suite/unit/Response/Handler/ResponseHandlerTest.php
@@ -20,6 +20,7 @@ class ResponseHandlerTest extends TestCase
 {
     /**
      * @covers ::handle
+     * @covers ::isResponseBodyEmpty
      */
     public function testResponse()
     {
@@ -59,6 +60,7 @@ class ResponseHandlerTest extends TestCase
 
     /**
      * @covers ::handle
+     * @covers ::isResponseBodyEmpty
      */
     public function testResponseWithDataAndExtraFields()
     {
@@ -98,6 +100,7 @@ class ResponseHandlerTest extends TestCase
 
     /**
      * @covers ::handle
+     * @covers ::isResponseBodyEmpty
      */
     public function testResponseWithData()
     {
@@ -137,6 +140,7 @@ class ResponseHandlerTest extends TestCase
 
     /**
      * @covers ::handle
+     * @covers ::isResponseBodyEmpty
      */
     public function testResponseEmpty()
     {
@@ -163,6 +167,7 @@ class ResponseHandlerTest extends TestCase
 
     /**
      * @covers ::handle
+     * @covers ::isResponseBodyEmpty
      */
     public function testResponseEmptyWhenBodySizeIsEmpty()
     {
@@ -196,6 +201,7 @@ class ResponseHandlerTest extends TestCase
     /**
      * @dataProvider exceptionsDataProvider
      * @covers ::handle
+     * @covers ::isResponseBodyEmpty
      */
     public function testHttpError(int $testStatusCode, string $exceptionClassName)
     {

--- a/test/suite/unit/Response/Handler/ResponseHandlerTest.php
+++ b/test/suite/unit/Response/Handler/ResponseHandlerTest.php
@@ -107,7 +107,7 @@ class ResponseHandlerTest extends TestCase
         $testRawBody     = '{"data":{"test-key":"test-value"}}';
         $testHeaders     = ['X-Foo' => 'bar'];
         $testBodySize    = 10;
-        $expectedBody    = ['test-key' => 'test-value'];
+        $expectedBody    = ['data' => ['test-key' => 'test-value']];
         $expectedHeaders = $testHeaders;
 
         $stream = $this->createMock(StreamInterface::class);
@@ -131,8 +131,8 @@ class ResponseHandlerTest extends TestCase
 
         $result = $handler->handle($response);
 
-        self::assertEquals($expectedBody, $result->getPayload());
         self::assertEquals($expectedHeaders, $result->getHeaders());
+        self::assertEquals($expectedBody, $result->getPayload());
     }
 
     /**
@@ -157,8 +157,8 @@ class ResponseHandlerTest extends TestCase
 
         $result = $handler->handle($response);
 
-        self::assertEquals([], $result->getPayload());
         self::assertEquals([], $result->getHeaders());
+        self::assertNull($result->getPayload());
     }
 
     /**
@@ -189,8 +189,8 @@ class ResponseHandlerTest extends TestCase
 
         $result = $handler->handle($response);
 
-        self::assertEquals([], $result->getPayload());
         self::assertEquals([], $result->getHeaders());
+        self::assertNull($result->getPayload());
     }
 
     /**
@@ -208,8 +208,12 @@ class ResponseHandlerTest extends TestCase
 
         $body = $this->createMock(StreamInterface::class);
         $body->expects(self::once())
+            ->method('getSize')
+            ->willReturn(20);
+
+        $body->expects(self::once())
             ->method('__toString')
-            ->willReturn('');
+            ->willReturn(json_encode(['error' => 'something went wrong']));
 
         $response->expects(self::once())
             ->method('getBody')

--- a/test/suite/unit/Response/ResponseTest.php
+++ b/test/suite/unit/Response/ResponseTest.php
@@ -35,10 +35,10 @@ class ResponseTest extends TestCase
     {
         $body         = ['foo'];
         $headers      = ['bar'];
-        $responseData = new Response(2000, $body, $headers);
+        $responseData = new Response(2000, $headers, $body);
 
         self::assertSame(2000, $responseData->getStatusCode());
-        self::assertSame($body, $responseData->getPayload());
         self::assertSame($headers, $responseData->getHeaders());
+        self::assertSame($body, $responseData->getPayload());
     }
 }


### PR DESCRIPTION
Handling 'data' key in the response body turned out is causing more problems than it helps, so decided to remove it overall.
It can be handled on each client how they are decoding payload, but not on this abstract level.