### PR TITLE
Fixed constructor parameter order in Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2020-09-07
+### Fixed
+- construct parameter order in `Response`
+
 ## [3.0.1] - 2020-09-03
 ### Fixed
 - version in composer.json

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "docler-labs/api-client-base",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "SDK Generator - API Client Base",
     "type": "library",
     "license": "MIT",

--- a/src/Response/Handler/ResponseHandler.php
+++ b/src/Response/Handler/ResponseHandler.php
@@ -41,12 +41,12 @@ class ResponseHandler implements ResponseHandlerInterface
 
         if ($statusCode >= 200 && $statusCode < 300) {
             if ($isResponseBodyEmpty) {
-                return new Response($statusCode, $headers);
+                return new Response($statusCode, null, $headers);
             }
 
             $decodedPayload = Json::decode($responseBody, true, 512, self::JSON_OPTIONS);
 
-            return new Response($statusCode, $headers, $decodedPayload);
+            return new Response($statusCode, $decodedPayload, $headers);
         }
 
         if ($statusCode === 400) {

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -8,16 +8,16 @@ class Response
     private $statusCode;
 
     /** @var array */
-    private $headers;
-
-    /** @var array */
     private $payload;
 
-    public function __construct(int $statusCode, array $headers = [], $payload = null)
+    /** @var array */
+    private $headers;
+
+    public function __construct(int $statusCode, $payload = null, array $headers = [])
     {
         $this->statusCode = $statusCode;
-        $this->headers    = $headers;
         $this->payload    = $payload;
+        $this->headers    = $headers;
     }
 
     public function getStatusCode(): int
@@ -25,13 +25,13 @@ class Response
         return $this->statusCode;
     }
 
-    public function getHeaders(): array
-    {
-        return $this->headers;
-    }
-
     public function getPayload()
     {
         return $this->payload;
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
     }
 }

--- a/test/suite/unit/Response/ResponseTest.php
+++ b/test/suite/unit/Response/ResponseTest.php
@@ -35,7 +35,7 @@ class ResponseTest extends TestCase
     {
         $body         = ['foo'];
         $headers      = ['bar'];
-        $responseData = new Response(2000, $headers, $body);
+        $responseData = new Response(2000, $body, $headers);
 
         self::assertSame(2000, $responseData->getStatusCode());
         self::assertSame($headers, $responseData->getHeaders());


### PR DESCRIPTION
api-client-generator uses this ordering so to easily revert breaking change, i propose to change back constructor parameter order